### PR TITLE
Added prop types to the wrapPageElement, fixes eslint error

### DIFF
--- a/src/helpers/wrapPageElement.js
+++ b/src/helpers/wrapPageElement.js
@@ -1,8 +1,14 @@
 import React from 'react';
 import Transition from 'components/transition';
+import PropTypes from 'prop-types';
 
 const wrapPageElement = ({ element, props }) => {
   return <Transition {...props}>{element}</Transition>;
+};
+
+wrapPageElement.propTypes = {
+  element: PropTypes.any,
+  props: PropTypes.any,
 };
 
 export default wrapPageElement;


### PR DESCRIPTION
Added the prop types to the wrapPageElement react component to ensure the code could compile without edits.