### PR TITLE
Fix png importing problem

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -25,7 +25,7 @@ module.exports = {
       resolve: `gatsby-plugin-react-svg`,
       options: {
         rule: {
-          include: /images/,
+          include: /images\/.*\.svg$/,
         },
       },
     },


### PR DESCRIPTION
Every time a *.png file was imported an error was happening:
```
error  in ./src/images/test.png

Module parse failed: Unexpected character '�' (1:0)
```

Searching for this error I stumbled into [this](https://github.com/jacobmischka/gatsby-plugin-react-svg#i-get-error-module-parse-failed-in-console) and fixed it by changing the include rule for gatsby-plugin-react-svg